### PR TITLE
Add support for the MLX90614

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 main/Configuration_*.h
+.vscode/

--- a/installArduino.md
+++ b/installArduino.md
@@ -33,6 +33,8 @@ https://www.arduino.cc/en/Main/Software
 
 <img hspace="50" src="images/installArduinoIDE-5.gif">
 
+- If you're using the MLX90614, enter "90614" in the search box and then install "Adafruit MLX90614 Library" (not the MINI version)
+
 - Connect the Adafruit Bluefruit board to your computer's USB and choose the corresponding COM port
 
 <img hspace="50" src="images/installArduinoIDE-6.gif">

--- a/main/Configuration.h
+++ b/main/Configuration.h
@@ -38,6 +38,9 @@
 #elif FIS_SENSOR == FIS_AMG8833
   #define IGNORE_TOP_ROWS    2
   #define IGNORE_BOTTOM_ROWS 2
+#elif FIS_SENSOR == FIS_MLX90614
+  #define IGNORE_TOP_ROWS    0
+  #define IGNORE_BOTTOM_ROWS 0
 #endif
 
 #define COLUMN_AGGREGATE   COLUMN_AGGREGATE_AVG_MINUS_OUTLIERS // Set column aggregation algorhytm, see Constants.h
@@ -144,6 +147,9 @@
 #elif FIS_SENSOR == FIS_AMG8833
   #define FIS_X            8
   #define FIS_Y            8
+#elif FIS_SENSOR == FIS_MLX90614
+  #define FIS_X            1
+  #define FIS_Y            1
 #endif
 
 #define EFFECTIVE_ROWS ( FIS_Y - IGNORE_TOP_ROWS - IGNORE_BOTTOM_ROWS )

--- a/main/Constants.h
+++ b/main/Constants.h
@@ -3,6 +3,7 @@
 #define FIS_MLX90640 1
 #define FIS_DUMMY    2
 #define FIS_AMG8833  3
+#define FIS_MLX90614 4   // Make sure the Adafruit MLX90614 library is installed when using this
 
 // Distance sensor identifiers
 #define DIST_VL53L0X 0

--- a/main/temp_sensor.h
+++ b/main/temp_sensor.h
@@ -7,6 +7,8 @@
   #include "MLX90640.h"
 #elif FIS_SENSOR == FIS_AMG8833
   #include "Melopero_AMG8833.h"
+#elif FIS_SENSOR == FIS_MLX90614
+  #include <Adafruit_MLX90614.h>
 #endif
 
 #define ABS_ZERO -2732
@@ -37,6 +39,8 @@ private:
   MLX90640 FISDevice;
 #elif FIS_SENSOR == FIS_AMG8833
   Melopero_AMG8833 FISDevice;
+#elif FIS_SENSOR == FIS_MLX90614
+  Adafruit_MLX90614 FISDevice;
 #endif
   
   TwoWire *thisWire;


### PR DESCRIPTION
I had what I thought were MLX90621 sensors, but turns out the AliExpress seller was (intentionally?) misleading, and actually had MLX90614 sensors. Added code to support the use of the 90614 so I can do things while I figure out whether to get 90640 or AMG8833.