### PR TITLE
Add feature to rotate sensor

### DIFF
--- a/main/Configuration.h
+++ b/main/Configuration.h
@@ -63,6 +63,14 @@
 #endif
                                  // NOTE!!! THESE CAN BE OVERRIDDEN WITH HARDWARE CODING WITH A GPIO PIN
                           
+
+#if FIS_SENSOR == FIS_AMG8833
+//Untested with other sensors so only enabled for AMG8833
+#define ROTATETIRE 1  // 0 = default \
+                      // 1 = Rotate the tire (A), making the top edge temps the outside edge temps \
+                      // Can be used with mirror to rotate the other way
+#endif
+
 // -- General settings
 
 #define DEVICENAMECODE 7      // DEFAULT is 7

--- a/main/Configuration.h
+++ b/main/Configuration.h
@@ -66,7 +66,7 @@
 
 #if FIS_SENSOR == FIS_AMG8833
 //Untested with other sensors so only enabled for AMG8833
-#define ROTATETIRE 1  // 0 = default \
+#define ROTATETIRE 0  // 0 = default \
                       // 1 = Rotate the tire (A), making the top edge temps the outside edge temps \
                       // Can be used with mirror to rotate the other way
 #endif

--- a/main/main.ino
+++ b/main/main.ino
@@ -12,6 +12,7 @@ TempSensor tempSensor;
 DistSensor distSensor;
 uint8_t mirrorTire = 0;
 char wheelPos[] = "  ";  // Wheel position for Tire A
+bool rotateTire = false;
 char deviceNameSuffix[] = "  ";
 
 #if BOARD == BOARD_ESP32_LOLIND32
@@ -106,6 +107,15 @@ void setup(){
       debug("ERROR: Distance sensor for %s not present.\n", wheelPos);
     }
   #endif
+#ifdef ROTATETIRE
+  // TIRE 1 ROTATED?
+  if (ROTATETIRE == 1)
+  {
+    rotateTire = true;
+    debug("Temperature sensor orientation for %s is rotated.\n", wheelPos);
+  }
+#endif
+
 
   debug("Starting temperature sensor for %s...\n", wheelPos);
   if (!tempSensor.initialise(FIS_REFRESHRATE, &Wire)) {

--- a/main/main.ino
+++ b/main/main.ino
@@ -107,6 +107,7 @@ void setup(){
       debug("ERROR: Distance sensor for %s not present.\n", wheelPos);
     }
   #endif
+  
 #ifdef ROTATETIRE
   // TIRE 1 ROTATED?
   if (ROTATETIRE == 1)
@@ -196,7 +197,7 @@ void loop() {
   #if DIST_SENSOR != DIST_NONE
     distSensor.measure();
   #endif
-  tempSensor.measure();
+  tempSensor.measure(rotateTire);
 
 // I2C channel 2
 #if FIS_SENSOR2_PRESENT == 1

--- a/main/temp_sensor.cpp
+++ b/main/temp_sensor.cpp
@@ -5,7 +5,6 @@
 #include <Wire.h>
 #include "spline.h"
 
-
 boolean TempSensor::initialise(int refrate, TwoWire *I2Cpipe) {
   innerTireEdgePositionThisFrameViaSlopeMin = FIS_X;
   outerTireEdgePositionThisFrameViaSlopeMax = 0;
@@ -24,8 +23,8 @@ boolean TempSensor::initialise(int refrate, TwoWire *I2Cpipe) {
 #endif
 };
 
-void TempSensor::measure() {
-	
+void TempSensor::measure(bool rotateTire) {
+
   int16_t column_content[EFFECTIVE_ROWS];
   float avgMins = 0.0;
   float avgMaxs = 0.0;
@@ -38,14 +37,14 @@ void TempSensor::measure() {
   FISDevice.updateThermistorTemperature();
   FISDevice.updatePixelMatrix();
 #endif
-  
-  for(uint8_t x=0; x<FIS_X; x++){
-    for (uint8_t y=0; y<EFFECTIVE_ROWS; y++) { // Read the columns first
-      column_content[y] = getPixelTemperature(x, y);
+
+  for (uint8_t x = 0; x < FIS_X; x++) {
+    for (uint8_t y = 0; y < EFFECTIVE_ROWS; y++) {  // Read the columns first
+      column_content[y] = getPixelTemperature(x, y, rotateTire);
     }
     measurement[x] = calculateColumnTemperature(column_content, EFFECTIVE_ROWS);
-    avgMins = ((float)getMinimum(column_content, EFFECTIVE_ROWS) - avgMins) / (x+1);
-    avgMaxs = ((float)getMaximum(column_content, EFFECTIVE_ROWS) - avgMaxs) / (x+1);
+    avgMins = ((float)getMinimum(column_content, EFFECTIVE_ROWS) - avgMins) / (x + 1);
+    avgMaxs = ((float)getMaximum(column_content, EFFECTIVE_ROWS) - avgMaxs) / (x + 1);
   }
 
   // reset average temperatures
@@ -64,48 +63,60 @@ void TempSensor::measure() {
   getMinMaxSlopePosition();
   validAutozoomFrame = checkAutozoomValidityAndSetAvgTemps();
   if (validAutozoomFrame) {
-    float leftStepSize = abs((outerTireEdgePositionThisFrameViaSlopeMax-outerTireEdgePositionSmoothed)/4);
-    float rightStepSize = abs((innerTireEdgePositionThisFrameViaSlopeMin-innerTireEdgePositionSmoothed)/4);
-    if (outerTireEdgePositionSmoothed < outerTireEdgePositionThisFrameViaSlopeMax) outerTireEdgePositionSmoothed += leftStepSize;
-    else outerTireEdgePositionSmoothed -= leftStepSize;
-    if (innerTireEdgePositionSmoothed < innerTireEdgePositionThisFrameViaSlopeMin) innerTireEdgePositionSmoothed += rightStepSize;
-    else innerTireEdgePositionSmoothed -= rightStepSize;
-    if (innerTireEdgePositionSmoothed < 0) outerTireEdgePositionSmoothed = 0;
-    if (outerTireEdgePositionSmoothed < 0) innerTireEdgePositionSmoothed = 0;
-    if (outerTireEdgePositionSmoothed > FIS_X) outerTireEdgePositionSmoothed = FIS_X;
-    if (innerTireEdgePositionSmoothed > FIS_X) innerTireEdgePositionSmoothed = FIS_X;
+    float leftStepSize = abs((outerTireEdgePositionThisFrameViaSlopeMax - outerTireEdgePositionSmoothed) / 4);
+    float rightStepSize = abs((innerTireEdgePositionThisFrameViaSlopeMin - innerTireEdgePositionSmoothed) / 4);
+    if (outerTireEdgePositionSmoothed < outerTireEdgePositionThisFrameViaSlopeMax)
+      outerTireEdgePositionSmoothed += leftStepSize;
+    else
+      outerTireEdgePositionSmoothed -= leftStepSize;
+    if (innerTireEdgePositionSmoothed < innerTireEdgePositionThisFrameViaSlopeMin)
+      innerTireEdgePositionSmoothed += rightStepSize;
+    else
+      innerTireEdgePositionSmoothed -= rightStepSize;
+    if (innerTireEdgePositionSmoothed < 0)
+      outerTireEdgePositionSmoothed = 0;
+    if (outerTireEdgePositionSmoothed < 0)
+      innerTireEdgePositionSmoothed = 0;
+    if (outerTireEdgePositionSmoothed > FIS_X)
+      outerTireEdgePositionSmoothed = FIS_X;
+    if (innerTireEdgePositionSmoothed > FIS_X)
+      innerTireEdgePositionSmoothed = FIS_X;
   }
 #else
-    avgsThisFrame.avgFrameTemp = getAverage(measurement, FIS_X);
+  avgsThisFrame.avgFrameTemp = getAverage(measurement, FIS_X);
 #endif
 
   // update running averages
   runningAvgOutlierRate += (((float)totalOutliersThisFrame / ((float)FIS_X * (float)EFFECTIVE_ROWS)) - runningAvgOutlierRate) / totalFrameCount;
   runningAvgZoomedFramesRate += ((validAutozoomFrame ? 1 : 0) - runningAvgZoomedFramesRate) / totalFrameCount;
-  movingAvgFrameTmp = (0.2 * avgsThisFrame.avgFrameTemp) + (0.8 * movingAvgFrameTmp); // exponential moving average
-  movingAvgStdDevFrameTmp = (0.2 * (avgsThisFrame.stdDevFrameTemp < MIN_TMP_STDDEV ? MIN_TMP_STDDEV : avgsThisFrame.stdDevFrameTemp)) + (0.8 * movingAvgStdDevFrameTmp); // exponential moving average retaining a minimum standard deviation of 20 degrees Celsius
-  if (totalOutliersThisFrame == 0) { // only if we have an outlier-free frame; exponential moving average 
-    movingAvgRowDeltaTmp = (0.2 * (avgsThisFrame.avgMaxFrameTemp - avgsThisFrame.avgMinFrameTemp)) + (0.8 * movingAvgRowDeltaTmp); // exponential moving average
-    if (movingAvgRowDeltaTmp > maxRowDeltaTmp) maxRowDeltaTmp = movingAvgRowDeltaTmp; // if we have a new contender for highest (filtered) delta temperature
+  movingAvgFrameTmp = (0.2 * avgsThisFrame.avgFrameTemp) + (0.8 * movingAvgFrameTmp);                                                                                     // exponential moving average
+  movingAvgStdDevFrameTmp = (0.2 * (avgsThisFrame.stdDevFrameTemp < MIN_TMP_STDDEV ? MIN_TMP_STDDEV : avgsThisFrame.stdDevFrameTemp)) + (0.8 * movingAvgStdDevFrameTmp);  // exponential moving average retaining a minimum standard deviation of 20 degrees Celsius
+  if (totalOutliersThisFrame == 0) {                                                                                                                                      // only if we have an outlier-free frame; exponential moving average
+    movingAvgRowDeltaTmp = (0.2 * (avgsThisFrame.avgMaxFrameTemp - avgsThisFrame.avgMinFrameTemp)) + (0.8 * movingAvgRowDeltaTmp);                                        // exponential moving average
+    if (movingAvgRowDeltaTmp > maxRowDeltaTmp)
+      maxRowDeltaTmp = movingAvgRowDeltaTmp;  // if we have a new contender for highest (filtered) delta temperature
   }
-  
+
   interpolate((int)outerTireEdgePositionSmoothed, (int)innerTireEdgePositionSmoothed, measurement_16);
 }
 
-int16_t TempSensor::getPixelTemperature(uint8_t x, uint8_t y) {
+int16_t TempSensor::getPixelTemperature(uint8_t x, uint8_t y, bool rotateTire) {
 #if FIS_SENSOR == FIS_MLX90621
-  return (int16_t)(FISDevice.getTemperature(y+IGNORE_TOP_ROWS+x*FIS_Y) + TEMPOFFSET) * 10 * TEMPSCALING; // MLX90621 iterates in columns
+  return (int16_t)(FISDevice.getTemperature(y + IGNORE_TOP_ROWS + x * FIS_Y) + TEMPOFFSET) * 10 * TEMPSCALING;  // MLX90621 iterates in columns
 #elif FIS_SENSOR == FIS_MLX90640
-  return (int16_t)(FISDevice.getTemperature(y*FIS_X+IGNORE_TOP_ROWS*FIS_X+x) + TEMPOFFSET) * 10 * TEMPSCALING; // MLX90640 iterates in rows
+  return (int16_t)(FISDevice.getTemperature(y * FIS_X + IGNORE_TOP_ROWS * FIS_X + x) + TEMPOFFSET) * 10 * TEMPSCALING;  // MLX90640 iterates in rows
 #elif FIS_SENSOR == FIS_AMG8833
-  return (int16_t)(FISDevice.pixelMatrix[x][y+IGNORE_TOP_ROWS] + TEMPOFFSET) * 10 * TEMPSCALING; 
+  if (rotateTire)
+    return (int16_t)(FISDevice.pixelMatrix[y + IGNORE_TOP_ROWS][x] + TEMPOFFSET) * 10 * TEMPSCALING;
+  else
+    return (int16_t)(FISDevice.pixelMatrix[x][y + IGNORE_TOP_ROWS] + TEMPOFFSET) * 10 * TEMPSCALING;
 #elif FIS_SENSOR == FIS_MLX90614
   double temp = FISDevice.readObjectTempC();
   if (temp == NAN) {
     // reading failed
     return ABS_ZERO;
   }
-  return (int16_t)(temp + TEMPOFFSET) * 10 * TEMPSCALING; // MLX90614 only has one pixel
+  return (int16_t)(temp + TEMPOFFSET) * 10 * TEMPSCALING;  // MLX90614 only has one pixel
 #endif
 }
 
@@ -123,27 +134,30 @@ int16_t TempSensor::calculateColumnTemperature(int16_t column_content[], uint8_t
 }
 
 void TempSensor::interpolate(uint8_t startColumn, uint8_t endColumn, int16_t result[]) {
-  float stepSize = (endColumn-startColumn)/16.0;
+  float stepSize = (endColumn - startColumn) / 16.0;
   int16_t x[FIS_X];
-  
-  for (uint8_t i=0; i<FIS_X; i++) x[i]=i; // Initialize the X axis of an array {0, 1, 2 ... 30, 31}
+
+  for (uint8_t i = 0; i < FIS_X; i++)
+    x[i] = i;  // Initialize the X axis of an array {0, 1, 2 ... 30, 31}
   Spline linearSpline(x, measurement, FIS_X, 1);
-  for (uint8_t i=0; i<16; i++) result[i] = linearSpline.value(startColumn+i*stepSize);
+  for (uint8_t i = 0; i < 16; i++)
+    result[i] = linearSpline.value(startColumn + i * stepSize);
 }
 
 void TempSensor::calculateSlope(int16_t result[]) {
-  for (uint8_t i=0; i<FIS_X-1; i++) result[i] = measurement[i+1]-measurement[i];
+  for (uint8_t i = 0; i < FIS_X - 1; i++)
+    result[i] = measurement[i + 1] - measurement[i];
 }
 
 void TempSensor::getMinMaxSlopePosition() {
   int16_t minSlopeValue = 0;
   int16_t maxSlopeValue = 0;
-  for (uint8_t i=0; i<FIS_X-1; i++) {
-    if (measurement_slope[i] > maxSlopeValue ) {
+  for (uint8_t i = 0; i < FIS_X - 1; i++) {
+    if (measurement_slope[i] > maxSlopeValue) {
       maxSlopeValue = measurement_slope[i];
-      outerTireEdgePositionThisFrameViaSlopeMax = i+1; // we want the first pixel on the tire; make up for the shift between measurement_slope[] and measurement[]
+      outerTireEdgePositionThisFrameViaSlopeMax = i + 1;  // we want the first pixel on the tire; make up for the shift between measurement_slope[] and measurement[]
     }
-    if (measurement_slope[i] < minSlopeValue ) {
+    if (measurement_slope[i] < minSlopeValue) {
       minSlopeValue = measurement_slope[i];
       innerTireEdgePositionThisFrameViaSlopeMin = i;
     }
@@ -154,16 +168,20 @@ boolean TempSensor::checkAutozoomValidityAndSetAvgTemps() {
   float avgTireTempThisFrame = 0.0;
   float avgInnerAmbientThisFrame = 0.0;
   float avgOuterAmbientThisFrame = 0.0;
-  
+
   avgsThisFrame.avgFrameTemp = getAverage(measurement, FIS_X);
   avgsThisFrame.stdDevFrameTemp = getStdDev(measurement, FIS_X);
 
-  if (measurement_slope[innerTireEdgePositionThisFrameViaSlopeMin] > -TMP_TRIGGER_DELTA_AMBIENT_TIRE) return false;
-  if (measurement_slope[outerTireEdgePositionThisFrameViaSlopeMax-1] < TMP_TRIGGER_DELTA_AMBIENT_TIRE) return false;
-  if (innerTireEdgePositionThisFrameViaSlopeMin < outerTireEdgePositionThisFrameViaSlopeMax) return false; // Inner or outer edge of tire out of camera view
-  if ((innerTireEdgePositionThisFrameViaSlopeMin-outerTireEdgePositionThisFrameViaSlopeMax+1) < AUTOZOOM_MINIMUM_TIRE_WIDTH) return false; // Too thin tire
-  
-  for (uint8_t i=0; i<FIS_X; i++) {
+  if (measurement_slope[innerTireEdgePositionThisFrameViaSlopeMin] > -TMP_TRIGGER_DELTA_AMBIENT_TIRE)
+    return false;
+  if (measurement_slope[outerTireEdgePositionThisFrameViaSlopeMax - 1] < TMP_TRIGGER_DELTA_AMBIENT_TIRE)
+    return false;
+  if (innerTireEdgePositionThisFrameViaSlopeMin < outerTireEdgePositionThisFrameViaSlopeMax)
+    return false;  // Inner or outer edge of tire out of camera view
+  if ((innerTireEdgePositionThisFrameViaSlopeMin - outerTireEdgePositionThisFrameViaSlopeMax + 1) < AUTOZOOM_MINIMUM_TIRE_WIDTH)
+    return false;  // Too thin tire
+
+  for (uint8_t i = 0; i < FIS_X; i++) {
     if (i < outerTireEdgePositionThisFrameViaSlopeMax) {
       avgOuterAmbientThisFrame += measurement[i];
     } else if (i > innerTireEdgePositionThisFrameViaSlopeMin) {
@@ -173,31 +191,33 @@ boolean TempSensor::checkAutozoomValidityAndSetAvgTemps() {
     }
   }
 
-  uint8_t tireWidthThisFrame = (innerTireEdgePositionThisFrameViaSlopeMin-outerTireEdgePositionThisFrameViaSlopeMax+1);
+  uint8_t tireWidthThisFrame = (innerTireEdgePositionThisFrameViaSlopeMin - outerTireEdgePositionThisFrameViaSlopeMax + 1);
   avgTireTempThisFrame = avgTireTempThisFrame / tireWidthThisFrame;
   avgInnerAmbientThisFrame = avgInnerAmbientThisFrame / outerTireEdgePositionThisFrameViaSlopeMax;
-  avgOuterAmbientThisFrame = avgOuterAmbientThisFrame / (FIS_X-innerTireEdgePositionThisFrameViaSlopeMin-1);
-  if (avgTireTempThisFrame - avgInnerAmbientThisFrame < TMP_AVG_DELTA_AMBIENT_TIRE) return false; // Tire is not significantly hotter than ambient
-  if (avgTireTempThisFrame - avgOuterAmbientThisFrame < TMP_AVG_DELTA_AMBIENT_TIRE) return false; // Tire is not significantly hotter than ambient
+  avgOuterAmbientThisFrame = avgOuterAmbientThisFrame / (FIS_X - innerTireEdgePositionThisFrameViaSlopeMin - 1);
+  if (avgTireTempThisFrame - avgInnerAmbientThisFrame < TMP_AVG_DELTA_AMBIENT_TIRE)
+    return false;  // Tire is not significantly hotter than ambient
+  if (avgTireTempThisFrame - avgOuterAmbientThisFrame < TMP_AVG_DELTA_AMBIENT_TIRE)
+    return false;  // Tire is not significantly hotter than ambient
 
   avgsThisFrame.avgTireTemp = avgTireTempThisFrame;
-  
+
   float avgOuterTireTempThisFrame = 0.0;
   float avgMiddleTireTempThisFrame = 0.0;
   float avgInnerTireTempThisFrame = 0.0;
-  for (uint8_t j=outerTireEdgePositionThisFrameViaSlopeMax; j<=innerTireEdgePositionThisFrameViaSlopeMin; j++) {
-    if (j <= (outerTireEdgePositionThisFrameViaSlopeMax+floor(tireWidthThisFrame/3))) {
+  for (uint8_t j = outerTireEdgePositionThisFrameViaSlopeMax; j <= innerTireEdgePositionThisFrameViaSlopeMin; j++) {
+    if (j <= (outerTireEdgePositionThisFrameViaSlopeMax + floor(tireWidthThisFrame / 3))) {
       avgOuterTireTempThisFrame += measurement[j];
-    } else if (j >= (innerTireEdgePositionThisFrameViaSlopeMin-floor(tireWidthThisFrame/3)+1)) {
+    } else if (j >= (innerTireEdgePositionThisFrameViaSlopeMin - floor(tireWidthThisFrame / 3) + 1)) {
       avgInnerTireTempThisFrame += measurement[j];
     } else {
       avgMiddleTireTempThisFrame += measurement[j];
     }
   }
 
-  avgsThisFrame.avgOuterTireTemp = avgOuterTireTempThisFrame / floor(tireWidthThisFrame/3);
-  avgsThisFrame.avgMiddleTireTemp = avgMiddleTireTempThisFrame / (tireWidthThisFrame-(2*floor(tireWidthThisFrame/3)));
-  avgsThisFrame.avgInnerTireTemp = avgInnerTireTempThisFrame / floor(tireWidthThisFrame/3);
+  avgsThisFrame.avgOuterTireTemp = avgOuterTireTempThisFrame / floor(tireWidthThisFrame / 3);
+  avgsThisFrame.avgMiddleTireTemp = avgMiddleTireTempThisFrame / (tireWidthThisFrame - (2 * floor(tireWidthThisFrame / 3)));
+  avgsThisFrame.avgInnerTireTemp = avgInnerTireTempThisFrame / floor(tireWidthThisFrame / 3);
   avgsThisFrame.avgOuterAmbientTemp = avgOuterAmbientThisFrame;
   avgsThisFrame.avgInnerAmbientTemp = avgInnerAmbientThisFrame;
   return true;
@@ -212,46 +232,50 @@ uint16_t TempSensor::removeOutliersChauvenet(int16_t *arr, int size) {
   float mean = movingAvgFrameTmp;
   float stdDev = movingAvgStdDevFrameTmp;
 
-  for (uint8_t i=0; i < size; i++) {
-    if (abs(arr[i]-mean) < abs(valueClosestToMean-mean)) valueClosestToMean = arr[i];
-    
+  for (uint8_t i = 0; i < size; i++) {
+    if (abs(arr[i] - mean) < abs(valueClosestToMean - mean))
+      valueClosestToMean = arr[i];
+
     float prob = cumulativeProbability((float)arr[i], mean, stdDev);
-    
-    if ( prob < significanceLevel || prob > (1-significanceLevel) || arr[i] == ABS_ZERO || arr[i] == 0 || arr[i] == ((-1 + TEMPOFFSET) * 10 * TEMPSCALING) ) {
+
+    if (prob < significanceLevel || prob > (1 - significanceLevel) || arr[i] == ABS_ZERO || arr[i] == 0 || arr[i] == ((-1 + TEMPOFFSET) * 10 * TEMPSCALING)) {
       Serial.printf("OUTLIER DETECTED IN FRAME %.0f: Column temps: ", totalFrameCount);
-      for (uint8_t u=0; u < size; u++) {
+      for (uint8_t u = 0; u < size; u++) {
         Serial.print(arr[u]);
         Serial.print(", ");
       }
       Serial.print("==> ");
       Serial.printf("mean: %.1f, ", mean);
-      if (outlierCount < (size-1)) {
-        Serial.printf("Outlier value to be removed: %i (probability %.1f%%); ", arr[i], prob*100);
+      if (outlierCount < (size - 1)) {
+        Serial.printf("Outlier value to be removed: %i (probability %.1f%%); ", arr[i], prob * 100);
         arr[i] = ABS_ZERO;
         outlierCount++;
       } else {
         // if we are about to remove the last array item, then we retain the one value closest to the mean
-        Serial.printf("Outlier value to be removed: %i (probability %.1f%%); Last column value set to: %i; ", arr[i], prob*100, valueClosestToMean);
+        Serial.printf("Outlier value to be removed: %i (probability %.1f%%); Last column value set to: %i; ", arr[i], prob * 100, valueClosestToMean);
         arr[i] = valueClosestToMean;
       }
     }
   }
-  if (outlierCount > 0) Serial.print("\n");
+  if (outlierCount > 0)
+    Serial.print("\n");
   return outlierCount;
 }
 
 int16_t TempSensor::getMaximum(int16_t arr[], int size) {
   int16_t max_value = arr[0];
-  for (uint8_t i=0; i < size; i++) {
-    if (arr[i] > ABS_ZERO && arr[i] > max_value) max_value = arr[i]; // ignore ABS_ZERO = outlier
+  for (uint8_t i = 0; i < size; i++) {
+    if (arr[i] > ABS_ZERO && arr[i] > max_value)
+      max_value = arr[i];  // ignore ABS_ZERO = outlier
   }
   return max_value;
 }
 
 int16_t TempSensor::getMinimum(int16_t arr[], int size) {
   int16_t min_value = arr[0];
-  for (uint8_t i=0; i < size; i++) {
-    if (arr[i] > ABS_ZERO && arr[i] < min_value) min_value = arr[i]; // ignore ABS_ZERO = outlier
+  for (uint8_t i = 0; i < size; i++) {
+    if (arr[i] > ABS_ZERO && arr[i] < min_value)
+      min_value = arr[i];  // ignore ABS_ZERO = outlier
   }
   return min_value;
 }
@@ -259,14 +283,14 @@ int16_t TempSensor::getMinimum(int16_t arr[], int size) {
 float TempSensor::getAverage(int16_t arr[], int size) {
   long total = 0;
   int sizeAfterOutliers = size;
-  for (uint8_t i=0; i < size; i++) {
-    if (arr[i] > ABS_ZERO) { // ignore ABS_ZERO = outlier
+  for (uint8_t i = 0; i < size; i++) {
+    if (arr[i] > ABS_ZERO) {  // ignore ABS_ZERO = outlier
       total += arr[i];
     } else {
       sizeAfterOutliers--;
     }
   }
-  float avg = total/(float)sizeAfterOutliers; // float for enhanced precision
+  float avg = total / (float)sizeAfterOutliers;  // float for enhanced precision
   return avg;
 }
 
@@ -275,8 +299,8 @@ float TempSensor::getGeometricMean(int16_t arr[], int size) {
   long long ex = 0;
   int sizeAfterOutliers = size;
 
-  for (uint8_t i=0; i < size; i++) {
-    if (arr[i] > ABS_ZERO) { // ignore ABS_ZERO = outlier
+  for (uint8_t i = 0; i < size; i++) {
+    if (arr[i] > ABS_ZERO) {  // ignore ABS_ZERO = outlier
       int exp;
       float f1 = frexp(arr[i], &exp);
       m *= f1;
@@ -287,7 +311,7 @@ float TempSensor::getGeometricMean(int16_t arr[], int size) {
   }
 
   float invN = 1.0 / sizeAfterOutliers;
-//  float gmMean = powf(std::numeric_limits<float>::radix, ex * invN) * powf(m, invN); // not compatible to nrf52
+  //  float gmMean = powf(std::numeric_limits<float>::radix, ex * invN) * powf(m, invN); // not compatible to nrf52
   float gmMean = scalblnf(1, ex * invN) * powf(m, invN);
   return gmMean;
 }
@@ -299,24 +323,25 @@ float TempSensor::getStdDev(int16_t arr[], int size) {
   float oldM = 0.0;
   float S = 0;
   uint16_t k = 1;
-  for (uint8_t i=0; i < size; i++) {
-    if (arr[i] > ABS_ZERO) { // ignore ABS_ZERO = outlier
+  for (uint8_t i = 0; i < size; i++) {
+    if (arr[i] > ABS_ZERO) {  // ignore ABS_ZERO = outlier
       float x = (float)arr[i];
       oldM = M;
-      M = M + (x-M)/k;
-      S = S + (x-M)*(x-oldM);
+      M = M + (x - M) / k;
+      S = S + (x - M) * (x - oldM);
       k++;
     }
   }
-  if (k>1) variance = S/(k-1);
-  float stdDev = sqrt(variance); // float for enhanced precision
+  if (k > 1)
+    variance = S / (k - 1);
+  float stdDev = sqrt(variance);  // float for enhanced precision
   return stdDev;
 }
 
 float TempSensor::cumulativeProbability(float val, float avg, float stdDev) {
   float thisDev = val - avg;
   if (fabs(thisDev) > (40 * stdDev)) {
-    return thisDev < 0 ? 0.0 : 1.0; // if val is more than 40 standard deviations from the mean, 0 or 1 is returned, as in these cases we are close enough
+    return thisDev < 0 ? 0.0 : 1.0;  // if val is more than 40 standard deviations from the mean, 0 or 1 is returned, as in these cases we are close enough
   }
   float prob = 0.5 * (1 + erf(thisDev / (stdDev * M_SQRT2)));
   return prob;

--- a/main/temp_sensor.h
+++ b/main/temp_sensor.h
@@ -2,36 +2,37 @@
 #include <Arduino.h>
 #include <Wire.h>
 #if FIS_SENSOR == FIS_MLX90621
-  #include "MLX90621.h"
+#include "MLX90621.h"
 #elif FIS_SENSOR == FIS_MLX90640
-  #include "MLX90640.h"
+#include "MLX90640.h"
 #elif FIS_SENSOR == FIS_AMG8833
-  #include "Melopero_AMG8833.h"
+#include "Melopero_AMG8833.h"
 #elif FIS_SENSOR == FIS_MLX90614
-  #include <Adafruit_MLX90614.h>
+#include <Adafruit_MLX90614.h>
 #endif
 
 #define ABS_ZERO -2732
 #define MIN_TMP_STDDEV ((25 + TEMPOFFSET) * 10 * TEMPSCALING) // minimum standard deviation we use for outlier detection (25 degrees Celsius)
 #define TMP_TRIGGER_DELTA_AMBIENT_TIRE (7 * 10 * TEMPSCALING) // delta temperature threshold for detecting a tire edge
-#define TMP_AVG_DELTA_AMBIENT_TIRE (5 * 10 * TEMPSCALING) // tire needs to be significantly warmer than ambient temp
+#define TMP_AVG_DELTA_AMBIENT_TIRE (5 * 10 * TEMPSCALING)     // tire needs to be significantly warmer than ambient temp
 
-typedef struct {
-  float  avgFrameTemp = 0; // after normalizing to one row; full width = avg(FIS_X)
-  float  stdDevFrameTemp = 0; // after normalizing to one row; full width = avg(FIS_X)
-  float  avgMinFrameTemp = 0; // after normalizing to one row; full width = avg(FIS_X)
-  float  avgMaxFrameTemp = 0; // after normalizing to one row; full width = avg(FIS_X)
+typedef struct
+{
+  float avgFrameTemp = 0;    // after normalizing to one row; full width = avg(FIS_X)
+  float stdDevFrameTemp = 0; // after normalizing to one row; full width = avg(FIS_X)
+  float avgMinFrameTemp = 0; // after normalizing to one row; full width = avg(FIS_X)
+  float avgMaxFrameTemp = 0; // after normalizing to one row; full width = avg(FIS_X)
 
-  float  avgTireTemp = 0; // 0 if no valid autozoom frame
-  float  avgOuterTireTemp = 0; // 1/3 of outermost tire pixels; 0 if no valid autozoom frame 
-  float  avgMiddleTireTemp = 0; // 1/3 of middle tire pixels; 0 if no valid autozoom frame
-  float  avgInnerTireTemp = 0; // 1/3 of innermost tire pixels; 0 if no valid autozoom frame
-  float  avgOuterAmbientTemp = 0; // 0 if no valid autozoom frame
-  float  avgInnerAmbientTemp = 0; // 0 if no valid autozoom frame
-} avgTemps_t; // all temps in degrees Celsius x 10
+  float avgTireTemp = 0;         // 0 if no valid autozoom frame
+  float avgOuterTireTemp = 0;    // 1/3 of outermost tire pixels; 0 if no valid autozoom frame
+  float avgMiddleTireTemp = 0;   // 1/3 of middle tire pixels; 0 if no valid autozoom frame
+  float avgInnerTireTemp = 0;    // 1/3 of innermost tire pixels; 0 if no valid autozoom frame
+  float avgOuterAmbientTemp = 0; // 0 if no valid autozoom frame
+  float avgInnerAmbientTemp = 0; // 0 if no valid autozoom frame
+} avgTemps_t;                    // all temps in degrees Celsius x 10
 
-
-class TempSensor {
+class TempSensor
+{
 private:
 #if FIS_SENSOR == FIS_MLX90621
   MLX90621 FISDevice;
@@ -42,10 +43,10 @@ private:
 #elif FIS_SENSOR == FIS_MLX90614
   Adafruit_MLX90614 FISDevice;
 #endif
-  
+
   TwoWire *thisWire;
 
-  int16_t getPixelTemperature(uint8_t x, uint8_t y);
+  int16_t getPixelTemperature(uint8_t x, uint8_t y, bool rotateTire = false);
   int16_t calculateColumnTemperature(int16_t column_content[], uint8_t size);
   void interpolate(uint8_t startColumn, uint8_t endColumn, int16_t result[]);
   void calculateSlope(int16_t result[]);
@@ -58,16 +59,16 @@ private:
   float getStdDev(int16_t arr[], int size);
   float cumulativeProbability(float val, float avg, float stdDev);
   uint16_t removeOutliersChauvenet(int16_t *arr, int size);
-  
+
 public:
   int16_t measurement[FIS_X];
-  int16_t measurement_slope[FIS_X-1];
+  int16_t measurement_slope[FIS_X - 1];
   int16_t measurement_16[16];
   boolean validAutozoomFrame = false;
   uint8_t outerTireEdgePositionThisFrameViaSlopeMax; // i.e. the index of the first pixel _on_ the tire as detected for this measurement; corresponds to Max value in the Slope
   uint8_t innerTireEdgePositionThisFrameViaSlopeMin; // i.e. the index of the last pixel _on_ the tire as detected for this measurement; corresponds to Min value in the Slope
-  float outerTireEdgePositionSmoothed; // outer = left = array index 0
-  float innerTireEdgePositionSmoothed; // inner = right = array index FIS_X
+  float outerTireEdgePositionSmoothed;               // outer = left = array index 0
+  float innerTireEdgePositionSmoothed;               // inner = right = array index FIS_X
 
   avgTemps_t avgsThisFrame;
   uint16_t totalOutliersThisFrame = 0;
@@ -79,8 +80,8 @@ public:
   float movingAvgFrameTmp = (40.0 + TEMPOFFSET) * 10 * TEMPSCALING; // init value = 40 degrees Celsius
   float movingAvgStdDevFrameTmp = MIN_TMP_STDDEV;
   float movingAvgRowDeltaTmp = 0.0; // delta between all lowest row values vs. all highest row values of the frames
-  float maxRowDeltaTmp = 0.0; // maximum of the moving average to detect shaded rows through increasing deltas with increasingly warm tire temps vs. constantly cold bodywork
-  
-	boolean initialise(int refrate, TwoWire *I2Cpipe = &Wire);
-	void measure();
+  float maxRowDeltaTmp = 0.0;       // maximum of the moving average to detect shaded rows through increasing deltas with increasingly warm tire temps vs. constantly cold bodywork
+
+  boolean initialise(int refrate, TwoWire *I2Cpipe = &Wire);
+  void measure(bool rotateTire = false);
 };


### PR DESCRIPTION
Enables the sensor to be rotated to make the top edge of the sensor (as it is read by the software) the left edge of the tire.

Only for AMG8833 as I do not have any other sensor to test and them not being square could make things buggy.

I let the formatter do it's thing so it looks like a lot but the only logic change is on line 109-112 of temp_sensor.cpp, the rest is a bit of configuration and mainly formatting.